### PR TITLE
파파고 연동, 로그아웃시 타이틀로 이동, table drop 에러 해결

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,6 +1,7 @@
 import { createStackNavigator } from 'react-navigation-stack'; 
 import { createAppContainer } from 'react-navigation';
 
+import LoadingScreen from './Components/LoadingScreen';
 import MainScreen from './Components/MainScreen';
 import TitleScreen from './Components/TitleScreen';
 import Chatroom from './Components/Chat/Chatroom';
@@ -10,7 +11,10 @@ import SignUp_Detail from './Components/SignUp/SignUp_Detail';
 import SignUp_Interest from './Components/SignUp/SignUp_Interest';
 import SignUp_Done from './Components/SignUp/SignUp_Done';
 
-const AppStackNavigator = createStackNavigator({
+const RootNavigator = createStackNavigator({
+  Loading:{
+    screen: LoadingScreen
+  },
   Title:{
     screen: TitleScreen
   },
@@ -34,10 +38,12 @@ const AppStackNavigator = createStackNavigator({
   },
   Chatroom:{
     screen: Chatroom
-  },
-});
+  }}, {
+    initialRouteName: 'Loading'
+  }
+);
 
-export default createAppContainer(AppStackNavigator);
+export default createAppContainer(RootNavigator);
 
 
 

--- a/frontend/Components/AppTabNavigator/SettingTab.js
+++ b/frontend/Components/AppTabNavigator/SettingTab.js
@@ -61,15 +61,28 @@ export default class SettingTab extends Component {
     }
 
     onPressLogout() {
-        db.transaction(tx => {
-            tx.executeSql(
-                'DELETE FROM token',
-                [],
-                null,
-                (_,error) => console.error(error)
-            )
-        },(error) => console.error(error))
-        RootNavigator('Title')
+        Alert.alert(
+            'Really?',
+            'Press the Logout button to log out.',
+            [
+                {
+                    text: 'Cancel',
+                    style: 'cancel',
+                },
+                {text: 'LogOut', onPress: () => {
+                    db.transaction(tx => {
+                        tx.executeSql(
+                            'DELETE FROM token',
+                            [],
+                            null,
+                            (_,error) => console.error(error)
+                        )
+                    },(error) => console.error(error))
+                    RootNavigator('Title')
+                }},
+            ],
+            {cancelable: false},
+        );
     }
     onPressContect() {
         Linking.openURL('http://google.com');   // 이후 연락 가능한 페이지로 연동해야함
@@ -80,7 +93,7 @@ export default class SettingTab extends Component {
     onPressDeleteChatLog() {
         Alert.alert(
             'Really?',
-            'If you press OK, all chat logs will be deleted.',
+            'Press OK to delete all chat logs.',
             [
                 {
                     text: 'Cancel',

--- a/frontend/Components/AppTabNavigator/SettingTab.js
+++ b/frontend/Components/AppTabNavigator/SettingTab.js
@@ -100,7 +100,6 @@ export default class SettingTab extends Component {
             ],
             {cancelable: false},
         );
-        
     }
 }
 

--- a/frontend/Components/AppTabNavigator/SettingTab.js
+++ b/frontend/Components/AppTabNavigator/SettingTab.js
@@ -63,13 +63,13 @@ export default class SettingTab extends Component {
     onPressLogout() {
         db.transaction(tx => {
             tx.executeSql(
-                'DROP TABLE token',
+                'DELETE FROM token',
                 [],
                 null,
                 (_,error) => console.error(error)
             )
         },(error) => console.error(error))
-        this.props.navigation.navigate('TitleScreen');
+        RootNavigator('Title')
     }
     onPressContect() {
         Linking.openURL('http://google.com');   // 이후 연락 가능한 페이지로 연동해야함
@@ -89,7 +89,7 @@ export default class SettingTab extends Component {
                 {text: 'OK', onPress: () => {
                     db.transaction(tx => {
                         tx.executeSql(
-                            'DROP TABLE chatLog',
+                            'DELETE FROM chatLog',
                             [],
                             null,
                             (_,error) => console.error(error)

--- a/frontend/Components/Chat/Chatbox_other.js
+++ b/frontend/Components/Chat/Chatbox_other.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Linking, Alert  } from 'react-native';
 import { Button, Thumbnail } from 'native-base';
 
 export default class Chatbox_other extends Component {
@@ -12,13 +12,30 @@ export default class Chatbox_other extends Component {
                     <Thumbnail circular backgroundColor="#fff" style={style.thumbnail}
                         source={require('../../assets/default_thumbnail.png')}/>
                     <View>
-                        <Button style={style.messageBox}>
+                        <Button style={style.messageBox} onPress={onPressTextBox(data.message)}>
                             <Text style={style.text_message}> {data.message} </Text>
                         </Button>
                     </View>
                     <Text style={style.text_time}>  {data.Time.toString().substr(16, 5)}</Text>
                 </View>
             </View>
+        );
+    }
+
+    onPressTextBox(message) {
+        Alert.alert(
+            'Translate?',
+            'If you press OK button, you will be redirected to Papago translator.',
+            [
+                {
+                    text: 'Cancel',
+                    style: 'cancel',
+                },
+                {text: 'OK', onPress: () => {
+                    Linking.openURL('https://papago.naver.com/?sk=auto&tk=en&st=' + message);   // 이후 연락 가능한 페이지로 연동해야함
+                }},
+            ],
+            {cancelable: false},
         );
     }
 }

--- a/frontend/Components/Chat/Chatbox_other.js
+++ b/frontend/Components/Chat/Chatbox_other.js
@@ -3,6 +3,9 @@ import { View, Text, StyleSheet, Linking, Alert  } from 'react-native';
 import { Button, Thumbnail } from 'native-base';
 
 export default class Chatbox_other extends Component {
+    constructor() {
+        super();
+    }
     render() {
         const data = this.props.data;
         return (
@@ -12,7 +15,7 @@ export default class Chatbox_other extends Component {
                     <Thumbnail circular backgroundColor="#fff" style={style.thumbnail}
                         source={require('../../assets/default_thumbnail.png')}/>
                     <View>
-                        <Button style={style.messageBox} onPress={onPressTextBox(data.message)}>
+                        <Button style={style.messageBox} onLongPress={() => this.papagoAlert(data.message)}>
                             <Text style={style.text_message}> {data.message} </Text>
                         </Button>
                     </View>
@@ -22,10 +25,10 @@ export default class Chatbox_other extends Component {
         );
     }
 
-    onPressTextBox(message) {
+    papagoAlert = (message) => {
         Alert.alert(
             'Translate?',
-            'If you press OK button, you will be redirected to Papago translator.',
+            'Press OK to redirect the message to the papago translator.',
             [
                 {
                     text: 'Cancel',

--- a/frontend/Components/Chat/Chatbox_other.js
+++ b/frontend/Components/Chat/Chatbox_other.js
@@ -32,7 +32,7 @@ export default class Chatbox_other extends Component {
                     style: 'cancel',
                 },
                 {text: 'OK', onPress: () => {
-                    Linking.openURL('https://papago.naver.com/?sk=auto&tk=en&st=' + message);   // 이후 연락 가능한 페이지로 연동해야함
+                    Linking.openURL('https://papago.naver.com/?sk=auto&tk=en&st='+message);   // 이후 연락 가능한 페이지로 연동해야함
                 }},
             ],
             {cancelable: false},
@@ -69,11 +69,10 @@ const style = StyleSheet.create({
         marginBottom: 5,
     },
     text_time: {
-        fontSize : 13,
+        fontSize : 12,
         color: '#ddd',
     },
     text_message: {
         fontSize: 15,
     },
 })
-

--- a/frontend/Components/Chat/Chatroom-SideMenu.js
+++ b/frontend/Components/Chat/Chatroom-SideMenu.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
-import { Icon, } from 'native-base';
+import { Icon } from 'native-base';
 
 export default class Chatroom_SideMenu extends Component {
     constructor(props){

--- a/frontend/Components/Chat/Chatroom-SideMenu.js
+++ b/frontend/Components/Chat/Chatroom-SideMenu.js
@@ -32,6 +32,12 @@ export default class Chatroom_SideMenu extends Component {
                         </TouchableOpacity>
                     </View>
                     <View style={style.toolBox}>
+                        <TouchableOpacity onPress={() => this._onPressCamera()}>
+                            <View style={style.tool}>
+                                <Icon name='md-camera' style={style.tool_icon}/>
+                                <Text style={style.tool_text}>  Camera</Text>
+                            </View>
+                        </TouchableOpacity>
                         <TouchableOpacity onPress={() => this._onPressPicture()}>
                             <View style={style.tool}>
                                 <Icon name='md-images' style={style.tool_icon}/>
@@ -42,12 +48,6 @@ export default class Chatroom_SideMenu extends Component {
                             <View style={style.tool}>
                                 <Icon name='md-locate' style={style.tool_icon}/>
                                 <Text style={style.tool_text}>  Place Recommend</Text>
-                            </View>
-                        </TouchableOpacity>
-                        <TouchableOpacity onPress={() => this._onPressCamera()}>
-                            <View style={style.tool}>
-                                <Icon name='md-camera' style={style.tool_icon}/>
-                                <Text style={style.tool_text}>  Camera</Text>
                             </View>
                         </TouchableOpacity>
                     </View>

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -16,16 +16,15 @@ const io = require('socket.io-client');
 export default class Chatroom extends Component {
     constructor(props){
         super(props);
+    };
+
+    componentWillMount() {
         this.socket = io('http://101.101.160.185:3000');     
         this.socket.on('RECEIVE_MESSAGE', function(data){
-            addMessage(data);
-            //this.dbAdd(data);
+            console.log(RECEIVE_MESSAGE)
+            this.dbAdd(data);
         });
-        const addMessage = data => {
-            console.log(data);
-            this.setState({chatlog:[...this.state.chatlog, data]});
-        };
-    };
+    }
 
     static navigationOptions = {
         header: null
@@ -39,24 +38,8 @@ export default class Chatroom extends Component {
         chatlog:[], // 채팅로그
         key: 0,
     }
-
-    renderDrawer = () => {
-        return (
-            <View>
-                <ChatroomSideMenu/>
-            </View>
-        );
-    };
     
     componentDidMount() {  // table이 없으면 create
-        db.transaction(tx => {
-            tx.executeSql(  // chatlog 저장하는 table 생성하기
-                'CREATE TABLE if not exists chatLog (user_email TEXT NOT NULL, cr_id INTEGER NOT NULL, Time TEXT NOT NULL, message TEXT NOT NULL, PRIMARY KEY("user_email","cr_id","Time"))',
-                [],
-                null,
-                (_,error) => console.error(error)
-            )
-        },(error) => console.error(error))
         db.transaction(tx => {
             tx.executeSql(  // token에서 user_email 읽어오기
                 'SELECT user_email FROM token',
@@ -137,6 +120,14 @@ export default class Chatroom extends Component {
         );
     }
 
+    renderDrawer = () => {
+        return (
+            <View>
+                <ChatroomSideMenu/>
+            </View>
+        );
+    };
+
     dbAdd(newchat) {
         db.transaction( tx => {
             tx.executeSql(
@@ -170,7 +161,7 @@ export default class Chatroom extends Component {
                 message: this.state.message,
             }
             this.dbAdd(newchat)
-            //this.socket.emit('SEND_MESSAGE', newchat);
+            this.socket.emit('SEND_MESSAGE', newchat);
             this.setState({message: null});    
         }
     }
@@ -178,11 +169,6 @@ export default class Chatroom extends Component {
     handleBackButton = () => {  // 뒤로가기 누르면 전 탭으로 돌아감
         goback()
     };
-}
-
-const drawerStyles = {
-    drawer: { shadowColor: '#000000', shadowOpacity: 0.8, shadowRadius: 3},
-    main: {paddingLeft: 3},
 }
 
 const style = StyleSheet.create({
@@ -206,7 +192,7 @@ const style = StyleSheet.create({
     },
     font_header: {
         color: 'white',
-        fontSize: 35,
+        fontSize: 30,
         alignItems: 'center',
         fontWeight: 'bold',
     },

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -16,8 +16,7 @@ const io = require('socket.io-client');
 export default class Chatroom extends Component {
     constructor(props){
         super(props);
-        this.socket = io('http://101.101.160.185:3000'); 
-
+        this.socket = io('http://101.101.160.185:3000');     
         this.socket.on('RECEIVE_MESSAGE', function(data){
             addMessage(data);
             //this.dbAdd(data);
@@ -51,21 +50,19 @@ export default class Chatroom extends Component {
     
     componentDidMount() {  // table이 없으면 create
         db.transaction(tx => {
-            tx.executeSql(  //chatlog 저장하는 table 생성하기
+            tx.executeSql(  // chatlog 저장하는 table 생성하기
                 'CREATE TABLE if not exists chatLog (user_email TEXT NOT NULL, cr_id INTEGER NOT NULL, Time TEXT NOT NULL, message TEXT NOT NULL, PRIMARY KEY("user_email","cr_id","Time"))',
                 [],
                 null,
                 (_,error) => console.error(error)
             )
         },(error) => console.error(error))
-
         db.transaction(tx => {
-            tx.executeSql(  //chatlog 저장하는 table 생성하기
+            tx.executeSql(  // token에서 user_email 읽어오기
                 'SELECT user_email FROM token',
                 [],
-                (_, { rows: { _array }  }) => {    
-                    this.state.myEmail = _array[0].user_email;
-                },
+                (_, { rows: { _array }  }) =>     
+                    (_array != []) ? (this.state.myEmail = _array[0].user_email) :
                 (_,error) => console.error(error)
             )
         },(error) => console.error(error))
@@ -159,8 +156,9 @@ export default class Chatroom extends Component {
                 [this.state.cr_id],
                 (_, { rows: { _array }  }) => this.setState({ chatlog: _array }),
                 (_,error) => console.error(error)
-            );
-        },(error) => console.error(error))
+            )
+        },(error) => console.error(error)
+        )
     };
 
     _onPressSend(){
@@ -171,10 +169,8 @@ export default class Chatroom extends Component {
                 Time: Date(),
                 message: this.state.message,
             }
-            
             this.dbAdd(newchat)
-            
-            this.socket.emit('SEND_MESSAGE', newchat);
+            //this.socket.emit('SEND_MESSAGE', newchat);
             this.setState({message: null});    
         }
     }

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -16,15 +16,12 @@ const io = require('socket.io-client');
 export default class Chatroom extends Component {
     constructor(props){
         super(props);
-    };
-
-    componentWillMount() {
         this.socket = io('http://101.101.160.185:3000');     
         this.socket.on('RECEIVE_MESSAGE', function(data){
             console.log(RECEIVE_MESSAGE)
             this.dbAdd(data);
         });
-    }
+    };
 
     static navigationOptions = {
         header: null
@@ -39,7 +36,7 @@ export default class Chatroom extends Component {
         key: 0,
     }
     
-    componentDidMount() {  // table이 없으면 create
+    componentDidMount() {
         db.transaction(tx => {
             tx.executeSql(  // token에서 user_email 읽어오기
                 'SELECT user_email FROM token',

--- a/frontend/Components/Chat/ChatroomTab.js
+++ b/frontend/Components/Chat/ChatroomTab.js
@@ -16,7 +16,7 @@ export default class ChatroomTab extends Component {
         this.email = '',
         this.array = [],
         this.state = {
-            arrayHolder: [],
+            arrayHolder: [{title:'Test', roomID:'11111'}],
             textInput_Holder_Theme: '',
             isAlertVisible: false,
         }    

--- a/frontend/Components/Chat/ChatroomTab.js
+++ b/frontend/Components/Chat/ChatroomTab.js
@@ -137,10 +137,12 @@ export default class ChatroomTab extends Component {
                     keyExtractor = {(item, index) => String(index)}
                     ItemSeparatorComponent={this.FlatListItemSeparator}
                     renderItem={({ item }) =>
-                        <TouchableOpacity onPress={() => this._onPressChatroom(item)}>
-                            <Text style={styles.item}>
-                                # {item.title}{'\n'}# roomID: {item.roomID}
-                            </Text>
+                        <TouchableOpacity activeOpacity={0.5} onPress={() => this._onPressChatroom(item)}>
+                            <View style={styles.item}>
+                                <Text style={styles.item_font}>
+                                    # {item.title}{'\n'}# roomID: {item.roomID}
+                                </Text>
+                            </View>
                         </TouchableOpacity>
                     }
                 />
@@ -174,14 +176,15 @@ const styles = StyleSheet.create({
         backgroundColor : '#333'
     },
     item : {
-        flexDirection : 'row',
+        justifyContent : 'center',
         borderWidth : 1, 
         borderColor : '#333',
         backgroundColor: '#fff',
         borderRadius: 7,
         padding : 10,
-        fontSize : 18,
-        height : 77,
+    },
+    item_font : {
+        fontSize : 16,
     },
     textInputStyle:{
         textAlign : 'center',

--- a/frontend/Components/Chat/ChatroomTab.js
+++ b/frontend/Components/Chat/ChatroomTab.js
@@ -16,7 +16,7 @@ export default class ChatroomTab extends Component {
         this.email = '',
         this.array = [],
         this.state = {
-            arrayHolder: [{title:'Test', roomID:'11111'}],
+            arrayHolder: [],
             textInput_Holder_Theme: '',
             isAlertVisible: false,
             isSearchVisible: false,
@@ -100,6 +100,36 @@ export default class ChatroomTab extends Component {
         // },(error) => console.error(error))
     }
 
+    leaveChatRoom = (roomID) => { // 방 나가기
+        this.setState(prevState => {
+            const index = prevState.arrayHolder.findIndex(holder => holder.roomID === roomID);
+            prevState.arrayHolder.splice(index, 1);
+            return ({
+                arrayHolder: [...prevState.arrayHolder]
+            })
+        });
+        //todo: 근데 arrayHolder만 건드려서 그런가 방이 추가하면 다시 돌아오는 버그가 있음ㅠ
+        //나중에 유용하면 이용하시고 아니면 삭제해주세요ㅠ
+        //서버와도 연동해서 방에서 나가기 구현해야함.
+    }
+
+    _longPressChatroom = (roomID) => {  // 채팅방 꾹 누르면
+        Alert.alert(
+            'Exit?',
+            'Press the OK button to exit the chat room.',
+            [
+                {
+                    text: 'Cancel',
+                    style: 'cancel',
+                },
+                {text: 'OK', onPress: () => {
+                    this.leaveChatRoom(roomID);
+                }},
+            ],
+            {cancelable: false},
+        );
+    }
+
     _onPressChatroom = (item) => {
         this.props.navigation.navigate('Chatroom', {
             title: item.title,
@@ -140,12 +170,13 @@ export default class ChatroomTab extends Component {
     GetItem(item) {
         Alert.alert(item);
     }
+    
 
     render() {
         return (
             <View style={styles.container}>
                 <View style={styles.header}>
-                <Text style={styles.font_title}>ChatRoom</Text>
+                <Text style={styles.font_header}>ChatRoom</Text>
                     <View style={styles.febContainer}>
                         <TouchableOpacity
                             onPress={()=> this.setState({isAlertVisible:true})} 
@@ -154,15 +185,14 @@ export default class ChatroomTab extends Component {
                             <Icon name='chatbubbles' style={{color: '#FFF'}}/>
                     </TouchableOpacity>
                     <TouchableOpacity
-                            onPress={()=> this.searchBarShow()} 
-                            activeOpacity={0.7} 
-                            style={styles.button_search} >
-                            <Icon name='ios-search' style={{color: '#FFF'}}/>
+                        onPress={()=> this.searchBarShow()} 
+                        activeOpacity={0.7} 
+                        style={styles.button_search} >
+                        <Icon name='ios-search' style={{color: '#FFF'}}/>
                     </TouchableOpacity>
                     </View>
-                    </View>
-
-                    <DialogInput
+                </View>
+                <DialogInput
                     isDialogVisible = {this.state.isAlertVisible}
                     title={"Create Chatroom"}
                     message={"Type Theme"}
@@ -176,7 +206,8 @@ export default class ChatroomTab extends Component {
                     keyExtractor = {(item, index) => String(index)}
                     ItemSeparatorComponent={this.FlatListItemSeparator}
                     renderItem={({ item }) =>
-                        <TouchableOpacity activeOpacity={0.5} onPress={() => this._onPressChatroom(item)}>
+                        <TouchableOpacity activeOpacity={0.5} onLongPress={() => this._longPressChatroom(item.roomID)}
+                            onPress={() => this._onPressChatroom(item)}>
                             <View style={styles.item}>
                                 <Text style={styles.item_font}>
                                     # {item.title}{'\n'}# roomID: {item.roomID}
@@ -186,33 +217,38 @@ export default class ChatroomTab extends Component {
                     }
                 />
                 <View style={styles.febContainer}>
+                    <TouchableOpacity    // 같은 ID로 채팅 컴포넌트 사용 위해서 임시로 만든 버튼입니다. 추후 채팅방 입장이 완료되면 삭제해주세요.
+                        onPress={()=> this.insertChatRoom('111','ADMIN')} 
+                        activeOpacity={0.7} 
+                        style={styles.button_suggest}
+                        >
+                        <Icon name='md-aperture' style={{color: '#222'}}/>
+                    </TouchableOpacity>
                     <TouchableOpacity
-                            onPress={()=> this.suggestRoom()} 
-                            activeOpacity={0.7} 
-                            style={styles.button_suggest}
-                            >
-                            <Icon name='paw' style={{color: '#FFF'}}/>
+                        onPress={()=> this.suggestRoom()} 
+                        activeOpacity={0.7} 
+                        style={styles.button_suggest}
+                        >
+                        <Icon name='paw' style={{color: '#222'}}/>
                     </TouchableOpacity>
                 </View>
                 {
                     (this.state.isSearchVisible == true) ? (
-                    <View style = {styles.search}>
-                    <TextInput
-                        style={{height: 40, width: "75%", backgroundColor:'#666',  fontSize:18, borderRadius: 5,paddingLeft: 10}}
-                        placeholder="Search..."
-                        value={this.state.search}
-                        onChangeText={(search) => this.setState({search})}
-                    />
-                    <TouchableOpacity
-                        style={{backgroundColor: '#384850',width: 40, height: 40, borderRadius: 40, justifyContent : 'center', alignItems : 'center',
-                                marginLeft :15,marginRight: 15, backgroundColor:'#AAA'}} 
-                        onPress={()=>this.searchRoomByKeyword()}
-                    >
-                        <Icon name='ios-search' style={{color: '#FFF'}}/>
-                    </TouchableOpacity>
+                    <View style = {styles.searchBarConatiner}>
+                        <TextInput
+                            style={styles.searchBar}
+                            placeholder="Search..."
+                            value={this.state.search}
+                            onChangeText={(search) => this.setState({search})}
+                        />
+                        <TouchableOpacity
+                            style={styles.searchButton} 
+                            onPress={()=>this.searchRoomByKeyword()}>
+                            <Icon name='ios-search' style={{color: '#FFF'}}/>
+                        </TouchableOpacity>
                     </View> 
-                    ) :(<View style = {styles.hide}></View>)
-                    }
+                    ):(<View style = {styles.hide}></View>)
+                }
             </View>
         );
     }
@@ -220,47 +256,35 @@ export default class ChatroomTab extends Component {
 
 const styles = StyleSheet.create({
     container : {
+        flex : 1,
         justifyContent : 'flex-start',
         alignItems : 'center',
-        flex : 1,
         backgroundColor : '#333'
     },
     header: {
-        justifyContent: 'flex-start',
-        alignItems: 'center',
         flexDirection : "row",
         width:'100%',
-        height: 110,
+        height: 74,
+        justifyContent: 'flex-start',
+        alignItems: 'flex-end',
+        marginBottom: 15,
         backgroundColor: '#888',
     },
-    font_title: {
-        marginTop: 10,
-        marginLeft: 15,
+    font_header: {
         color: 'white',
-        fontSize: 35,
         alignItems: 'center',
+        fontSize: 42,
         fontWeight: 'bold',
-        },
-    search: {
-        marginTop: 65,
-        position : 'absolute',
-        flex: 3,
-        flexDirection: 'row',
-        justifyContent: 'center',
-        alignItems : "stretch",
-        paddingTop: 50,
-        paddingLeft : 20,
-        width:'100%',
-        
+        marginLeft: 15,
     },
     hide : {
     },
     febContainer: {
-        flexDirection : 'row',
-        marginTop: 20,
         flex: 2,
+        flexDirection : 'row',
         width: '100%',
         height: 50,
+        marginTop: 20,
         justifyContent: 'flex-end',
         alignItems: 'flex-end',
     },
@@ -268,51 +292,78 @@ const styles = StyleSheet.create({
         width:  50,
         height: 50,
         justifyContent: 'center',
-        backgroundColor: '#0054FF',
         alignItems: 'center',
+        marginRight: 30,
         borderRadius: 50,
-        marginRight: 50,
-
+        backgroundColor: '#33AAFF',
     },
     button_create: {
         width:  50,
         height: 50,
         justifyContent: 'center',
-        backgroundColor: '#1DDB16',
         alignItems: 'center',
-        marginRight: 20,
+        marginRight: 30,
         borderRadius: 50,
+        backgroundColor: '#44DD44',
     }, 
     button_suggest : {
-        backgroundColor: '#FFE400',
         width:  50,
         height: 50,
-        marginRight:  50,
-        marginBottom: 60,
         justifyContent: 'center',
         alignItems: 'center',
+        marginRight:  50,
+        marginBottom: 60,
         borderRadius: 50,
+        backgroundColor: '#eeee33',
     },
     item : {
+        padding : 10,
         justifyContent : 'center',
         borderWidth : 1, 
+        borderRadius: 7,
         borderColor : '#333',
         backgroundColor: '#fff',
-        borderRadius: 7,
-        padding : 10,
     },
     item_font : {
         fontSize : 16,
     },
     textInputStyle:{
-        textAlign : 'center',
-        height: 40,
         width: '85%',
-        borderWidth : 1, 
-        borderColor : '#4CAF50',
-        borderRadius: 7,
-        marginTop : 12,
+        height: 40,
+        textAlign : 'center',
         color : '#fff',
+        borderWidth : 1, 
+        borderRadius: 7,
+        borderColor : '#4CAF50',
+        marginTop : 12,
     },
-
-});
+    searchBarConatiner: {
+        position : 'absolute',
+        flex: 3,
+        flexDirection: 'row',
+        width:'100%',
+        justifyContent: 'center',
+        alignItems : "stretch",
+        marginTop: 90,
+        paddingLeft: 15,
+    },
+    searchBar:{
+        width: "75%",
+        height: 40,
+        fontSize:18,
+        color: '#ddd',
+        backgroundColor:'rgba(0, 0, 0, 0.8)',
+        paddingLeft: 10,
+        borderRadius: 5,
+    },
+    searchButton:{
+        width: 40,
+        height: 40,
+        borderRadius: 40,
+        justifyContent : 'center',
+        alignItems : 'center',
+        marginLeft :15,
+        marginRight: 15,
+        backgroundColor:'rgba(0, 0, 0, 0.5)',
+    }
+})

--- a/frontend/Components/LoadingScreen.js
+++ b/frontend/Components/LoadingScreen.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import { StyleSheet, View, Text} from 'react-native';
+
+import * as SQLite from 'expo-sqlite';
+const db = SQLite.openDatabase('db.db');
+
+export default class LoadingScreen extends Component {
+    static navigationOptions = {    // 상단바 안보이게 하기
+        header: null
+    }
+
+    componentWillMount() {
+        db.transaction(tx => {
+            tx.executeSql(              //chatlog 저장하는 table 생성하기
+                'CREATE TABLE if not exists token (access_token TEXT NOT NULL, user_email TEXT NOT NULL, PRIMARY KEY("access_token"))',
+                [],
+                null,
+                (_,error) => console.error(error)
+            )
+        },(error) => console.error(error))
+        db.transaction( tx => {
+            tx.executeSql(
+                'SELECT * FROM token',
+                [],
+                (_, { rows: { _array }  }) => {
+                    (_array.length)
+                    ? this.goMain()        // db에 토큰이 있으면 메인으로
+                    : this.goTitle()       // 없으면 타이틀로
+                },
+                (_,error) => console.error(error)
+            );
+        },(error) => console.error(error))
+    }
+
+    render() {
+        return (
+            <View style={style.container}>
+                <Text style={style.loadingFont}>Yumi</Text>
+                <Text style={style.loadingFont}>Loading</Text>
+            </View>
+        );
+    }
+
+    goMain(){
+        this.props.navigation.navigate('Main');
+    }
+    goTitle(){
+        this.props.navigation.navigate('Title');
+    }
+}
+
+const style = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingTop: '30%',
+        paddingBottom: '10%',
+        backgroundColor: '#444',
+    },
+    loadingFont: {
+        fontSize: 50,
+        color: '#ddd',
+        fontWeight: 'bold',
+    },
+});

--- a/frontend/Components/LoadingScreen.js
+++ b/frontend/Components/LoadingScreen.js
@@ -9,17 +9,22 @@ export default class LoadingScreen extends Component {
         header: null
     }
 
-    componentWillMount() {
+    constructor(props){
+        super(props);
         db.transaction(tx => {
-            tx.executeSql(              //chatlog 저장하는 table 생성하기
+            tx.executeSql(          // token 저장하는 table 생성하기
                 'CREATE TABLE if not exists token (access_token TEXT NOT NULL, user_email TEXT NOT NULL, PRIMARY KEY("access_token"))',
                 [],
                 null,
                 (_,error) => console.error(error)
             )
-        },(error) => console.error(error))
-        db.transaction( tx => {
-            tx.executeSql(
+            tx.executeSql(          // chatlog 저장하는 table 생성하기
+                'CREATE TABLE if not exists chatLog (user_email TEXT NOT NULL, cr_id INTEGER NOT NULL, Time TEXT NOT NULL, message TEXT NOT NULL, PRIMARY KEY("user_email","cr_id","Time"))',
+                [],
+                null,
+                (_,error) => console.error(error)
+            )
+            tx.executeSql(          // token 확인
                 'SELECT * FROM token',
                 [],
                 (_, { rows: { _array }  }) => {

--- a/frontend/Components/MainScreen.js
+++ b/frontend/Components/MainScreen.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { ToastAndroid, BackHandler, StatusBar } from 'react-native';
+import { ToastAndroid, BackHandler } from 'react-native';
 import { createMaterialTopTabNavigator } from 'react-navigation-tabs'; 
 import { createAppContainer } from 'react-navigation';
 
@@ -37,12 +37,12 @@ const AppTabContainet = createAppContainer(AppTabNavigator);
 export default class MainScreen extends Component {
     constructor (props) {
         super(props);
+        RootNavigator = (route) => {this.props.navigation.navigate(route)}
     }
     static navigationOptions = {    // 상단바 안보이게 하기
         header: null
     }
     render() {
-        <StatusBar hidden='yes' />
         return <AppTabContainet/>; 
     }
     componentDidMount() {   // 뒤로가기 눌렀을 때

--- a/frontend/Components/MainScreen.js
+++ b/frontend/Components/MainScreen.js
@@ -56,12 +56,7 @@ export default class MainScreen extends Component {
         if (this.exitApp == undefined || !this.exitApp) {
             ToastAndroid.show('Press once more to exit.', ToastAndroid.SHORT);
             this.exitApp = true;
-            this.timeout = setTimeout(
-                () => {
-                    this.exitApp = false;
-                },
-                2000                // 2초
-            );
+            this.timeout = setTimeout(() => {this.exitApp = false;}, 2000);
         } else {
             clearTimeout(this.timeout);
             BackHandler.exitApp();  // 앱 종료

--- a/frontend/Components/SignUp/Interest/InterestList.js
+++ b/frontend/Components/SignUp/Interest/InterestList.js
@@ -6,7 +6,7 @@ class ContactInfo extends Component {
     render() {
         const data = this.props.data;
         return (
-            <View>
+            <View key={data.key} >
                 <TouchableOpacity style={style.interestBox} onPress={() => this.props._onPress(data.key)}>
                     {
                         data.selected

--- a/frontend/Components/SignUp/SignUp_EmailAuth.js
+++ b/frontend/Components/SignUp/SignUp_EmailAuth.js
@@ -146,13 +146,9 @@ export default class SignUp_EmailAuth extends Component {
         });
     }
     submit(){
-        var email= {}
-        email.email = this.state.email
-        console.log(email);
-        var url = 'http://101.101.160.185:3000/user/send-email';
+        var url = 'http://101.101.160.185:3000/user/send-email/'+this.state.email;
         fetch(url, {
             method: 'POST',
-            body: JSON.stringify(email),
             headers: new Headers({
             'Content-Type' : 'application/json',
             'token': 'token'

--- a/frontend/Components/TitleScreen.js
+++ b/frontend/Components/TitleScreen.js
@@ -25,20 +25,18 @@ export default class TitleScreen extends Component {
                 (_,error) => console.error(error)
             )
         },(error) => console.error(error))
-
         db.transaction( tx => {
             tx.executeSql(
                 'SELECT * FROM token',
                 [],
                 (_, { rows: { _array }  }) => {    // TODO : 이 과정이 1초정도 걸리기 때문에 토큰이 있는 경우 타이틀 화면 갔다가 메인 페이지로 넘어가짐. 중간에 새로운 화면을 만들던지 해야할 듯.
-                    console.log(_array);
                     if(_array.length) this.goMain();  // db에 토큰이 있는지 검사
                 },
                 (_,error) => console.error(error)
             );
         },(error) => console.error(error))
     }
-    
+
     render() {
         return (
             <View style={style.container}>
@@ -84,8 +82,6 @@ export default class TitleScreen extends Component {
             </View>
         );
     }
-
-
     dbSaveToken(token){
         db.transaction( tx => {
             tx.executeSql(
@@ -131,7 +127,6 @@ export default class TitleScreen extends Component {
         var user= {}
         user.email = this.state.email
         user.password = this.state.password
-
         var url = 'http://101.101.160.185:3000/user/login';
         fetch(url, {
             method: 'POST',

--- a/frontend/Components/TitleScreen.js
+++ b/frontend/Components/TitleScreen.js
@@ -15,28 +15,13 @@ export default class TitleScreen extends Component {
         super(props);
         this.state={email: '', password: '', loginResult: -1, token:''}
     }
-
-    componentWillMount() {  // table이 없으면 create
-        db.transaction(tx => {
-            tx.executeSql(  //chatlog 저장하는 table 생성하기
-                'CREATE TABLE if not exists token (access_token TEXT NOT NULL, user_email TEXT NOT NULL, PRIMARY KEY("access_token"))',
-                [],
-                null,
-                (_,error) => console.error(error)
-            )
-        },(error) => console.error(error))
-        db.transaction( tx => {
-            tx.executeSql(
-                'SELECT * FROM token',
-                [],
-                (_, { rows: { _array }  }) => {    // TODO : 이 과정이 1초정도 걸리기 때문에 토큰이 있는 경우 타이틀 화면 갔다가 메인 페이지로 넘어가짐. 중간에 새로운 화면을 만들던지 해야할 듯.
-                    if(_array.length) this.goMain();  // db에 토큰이 있는지 검사
-                },
-                (_,error) => console.error(error)
-            );
-        },(error) => console.error(error))
+    componentWillMount() {
+        this.setState({
+            email: '',
+            password: '',
+            loginResult: -1,
+            token:''})
     }
-
     render() {
         return (
             <View style={style.container}>
@@ -60,11 +45,6 @@ export default class TitleScreen extends Component {
                             titleColor={'#ddd'}
                             buttonColor={'#000'}
                             onPress={() => this.goSignup_Welcome()}/>
-                        <CustomButton
-                            title={'chatroom'}
-                            titleColor={'#ddd'}
-                            buttonColor={'#000'}
-                            onPress={() => this.goChatroom()}/>
                     </View>
                     <View style={style.footer_nextbutton}>
                     <CustomButton
@@ -113,9 +93,6 @@ export default class TitleScreen extends Component {
         } else {                                     // 서버 전송 오류
             alert("Failed to login. Please try again.")
         }
-    }
-    goChatroom(){
-        this.props.navigation.navigate('Chatroom');
     }
     goSignup_Welcome(){
         this.props.navigation.navigate('SignUp_Welcome');


### PR DESCRIPTION
+ 상대방 채팅 말풍선 꾹 누르면 파파고로 연동됨.
+ 로그아웃시 타이틀 화면으로 이동
+ 로그아웃, 챗로그 삭제 연속으로 진행할 시 table drop 에러 해결

+ 회원가입시 interset list 고를 때  warning 발생하던 현상 해결
+ 회원가입시에도 토큰 저장
+ 채팅창 연동을 위한 chatroomTab에 테스트 방 생성 버튼 임시 생성 (채팅방 입장 기능 구현 시 삭제)


> chatroomTab에서 채팅방 퇴장 기능 일단 로컬에서만 이루어지도록 했는데 방 목록에 변화가 생기면 채팅방이 부활함...ㅠ 윤구형이 나중에 확인해주시면 감사하겠습니다

![ezgif-2-d4d2fc6a4298](https://user-images.githubusercontent.com/48412823/68885432-7fbf9580-0758-11ea-8995-365d0064f73b.gif)
