### PR TITLE
채팅방 입장 시 socket.id DB에 저장함

### DIFF
--- a/backend/models/chatRoom.js
+++ b/backend/models/chatRoom.js
@@ -6,7 +6,8 @@ const ChatRoomSchema = mongoose.Schema({
     participants: [{
         email: { type: String},
         nickname: { type: String},
-        interests: [{ type: String }]
+        interests: [{ type: String }],
+        socketID: { type: String }
     }],
     chatlog:[{
         user_email:{type: String},

--- a/backend/routes/chatroom/io.js
+++ b/backend/routes/chatroom/io.js
@@ -24,10 +24,10 @@ module.exports = function (server) {
                         if(chatroom.participants[i].socketID == undefined){
                             chatroom.participants[i].socketID = socket.id;
                             chatroom.save();
-                            console.log(1);
+                            console.log('socketID is undefined');
                             socket.join(data.cr_id);
                         } else{
-                            console.log(2);
+                            console.log('socketID already exists');
                             socket.id = chatroom.participants[i].socketID;
                         }
                     }

--- a/backend/routes/chatroom/io.js
+++ b/backend/routes/chatroom/io.js
@@ -29,6 +29,7 @@ module.exports = function (server) {
                         } else{
                             console.log('socketID already exists');
                             socket.id = chatroom.participants[i].socketID;
+                            socket.join(data.cr_id);
                         }
                     }
                 }

--- a/backend/routes/chatroom/io.js
+++ b/backend/routes/chatroom/io.js
@@ -2,13 +2,22 @@ module.exports = function (server) {
     var io = require('socket.io')(server);
     var PopQuiz = require('../../models/popQuiz');
 
-    io.on('connection', function (socket) {
+    io.sockets.on('connection', function (socket) {
         console.log(socket.id);
         socket.on('SEND_MESSAGE', function (data) {
             console.log(data);
-            io.emit('RECEIVE_MESSAGE', data); 
+            //socket.join(data.cr_id);
+            io.sockets.in(data.cr_id).emit('RECEIVE_MESSAGE', data); 
             //socket.emit('MY_MESSAGE', data); // 나한테만 메세지 전송함
             //socket.broadcast.emit('OTHER_MESSAGE', data); // 본인을 제외한 다른 사람들에게만 메세지 전송함
+        });
+
+        socket.on('JOIN_ROOM', function(cr_id){
+            socket.join(cr_id);
+        });
+
+        socket.on('LEAVE_ROOM', function(cr_id){
+            socket.leave(cr_id);
         });
     });
 


### PR DESCRIPTION
채팅방 입장 시 채팅방 참가 유저의 socket.id 유무를 확인. (DB에 저장이 되어 있는지를 체크)
없으면 DB에 저장한 후, 채팅방에 입장 시킴.
있으면 DB에 있는 socket.id를 입장했을 때의 socket.id로 바꿈
