### PR TITLE
채팅방 지연시간 최적화 및 re-render 지연 수정

### DIFF
--- a/frontend/Components/AppTabNavigator/ProfilePopup/EditAddress.js
+++ b/frontend/Components/AppTabNavigator/ProfilePopup/EditAddress.js
@@ -43,7 +43,8 @@ export default class EditAddress extends Component {
             ToastAndroid.show('Please select language.', ToastAndroid.SHORT)
             return
         }
-        var url = 'http://101.101.160.185:3000/user/profile/address/'+this.state.address;
+        const _address = this.state.address
+        var url = 'http://101.101.160.185:3000/user/profile/address/'+_address;
         fetch(url, {
             method: 'POST',
             headers: new Headers({
@@ -58,7 +59,7 @@ export default class EditAddress extends Component {
                 db.transaction(tx => {
                     tx.executeSql(  // DB에 바뀐 닉네임 저장
                         'UPDATE userInfo SET address = ?',
-                        [this.state.address],
+                        [_address],
                         null,
                         (_,error) => console.error(error)
                     )

--- a/frontend/Components/AppTabNavigator/ProfilePopup/EditInterest.js
+++ b/frontend/Components/AppTabNavigator/ProfilePopup/EditInterest.js
@@ -38,6 +38,7 @@ export default class EditInterest extends Component {
     }
 
     _onPressAdmit = () => {
+        const _interests = this.state.interests
         var url = 'http://101.101.160.185:3000/user/profile/interests';
         fetch(url, {
             method: 'POST',
@@ -47,7 +48,7 @@ export default class EditInterest extends Component {
             'x-access-token': this.props.token
             }),
             body: JSON.stringify({
-                "interests": this.state.interests
+                "interests": _interests
             })
         }).then(response => response.json())
         .catch(error => console.error('Error: ', error))

--- a/frontend/Components/AppTabNavigator/ProfilePopup/EditLanguage.js
+++ b/frontend/Components/AppTabNavigator/ProfilePopup/EditLanguage.js
@@ -36,12 +36,12 @@ export default class EditLanguage extends Component {
     }
 
     _onPressAdmit = () => {
-        console.log(this.state.language)
+        const _language = this.state.language
         if (this.state.language == "NoValue") {
             ToastAndroid.show('Please select language.', ToastAndroid.SHORT)
             return
         }
-        var url = 'http://101.101.160.185:3000/user/profile/language/'+this.state.language;
+        var url = 'http://101.101.160.185:3000/user/profile/language/'+_language;
         fetch(url, {
             method: 'POST',
             headers: new Headers({
@@ -56,7 +56,7 @@ export default class EditLanguage extends Component {
                 db.transaction(tx => {
                     tx.executeSql(  // DB에 바뀐 닉네임 저장
                         'UPDATE userInfo SET language = ?',
-                        [this.state.language],
+                        [_language],
                         null,
                         (_,error) => console.error(error)
                     )

--- a/frontend/Components/AppTabNavigator/ProfileTab.js
+++ b/frontend/Components/AppTabNavigator/ProfileTab.js
@@ -4,7 +4,7 @@ import { View, Text, Image, StyleSheet, Dimensions, TouchableOpacity } from 'rea
 import DialogInput from 'react-native-dialog-input';
 import { Icon, Thumbnail, Spinner } from 'native-base';
 
-import EditAddress from './ProfilePopup/EditAddress'
+//import EditAddress from './ProfilePopup/EditAddress'
 import EditInterest from './ProfilePopup/EditInterest'
 import EditLanguage from './ProfilePopup/EditLanguage'
 
@@ -20,7 +20,7 @@ export default class ProfileTab extends Component {
         myThumbnailURL: null, // 이후 기본 URL로 연동해야함.
         isAlertVisible: false,
         token: '',
-        spinnerOpacity: 1,
+        spinnerDisplay: 'flex',
         editAddrDisplay: 'none',
         editInterDisplay: 'none',
         editLangDisplay: 'none',
@@ -57,7 +57,7 @@ export default class ProfileTab extends Component {
                             myAddress: _array[0].address,
                             myLanguage: _array[0].language,
                             myThumbnailURL: _array[0].thumbnailURL, //이후 썸네일 구현되면 연동
-                            spinnerOpacity: 0
+                            spinnerDisplay: 'none',
                         })
                     )
                 },
@@ -122,9 +122,9 @@ export default class ProfileTab extends Component {
     //     .then(responseJson => {console.log(responseJson)})
     // }
 
-    _displayAddr = (display) => {
-        this.setState({editAddrDisplay: display})
-    }
+    // _displayAddr = (display) => {
+    //     this.setState({editAddrDisplay: display})
+    // }
 
     _displayInter = (display) => {
         this.setState({editInterDisplay: display})
@@ -159,10 +159,10 @@ export default class ProfileTab extends Component {
                     <Text style={style.font_email}>{this.state.myEmail}</Text>
                 </View>
                 <View style={style.febContainer}>
-                    <TouchableOpacity style={{alignItems: 'center'}} onPress={() => this._displayAddr('flex')}>
+                    {/*<TouchableOpacity style={{alignItems: 'center'}} onPress={() => this._displayAddr('flex')}>
                         <Icon name='md-pin' style={{fontSize: 32, margin: 4, color: '#444'}} />
                         <Text style={style.font_feb}>Address</Text>
-                    </TouchableOpacity>
+                    </TouchableOpacity>*/}
                     <TouchableOpacity style={{alignItems: 'center'}} onPress={() => this._displayInter('flex')}>
                         <Icon name='md-cafe' style={{fontSize: 32, margin: 4, color: '#444'}} />
                         <Text style={style.font_feb}>Interests</Text>
@@ -180,10 +180,10 @@ export default class ProfileTab extends Component {
                     ? <Thumbnail backgroundColor="#ddd" style={style.thumbnail} source={require('../../assets/default_thumbnail.png')}/>
                     : <Thumbnail backgroundColor="#ddd" style={style.thumbnail} source={{ uri: this.state.myThumbnailURL }}/>}
                 </TouchableOpacity>
-                <EditAddress token={this.state.token} displayChange={this._displayAddr} display={this.state.editAddrDisplay}/>
+                {/*<EditAddress token={this.state.token} displayChange={this._displayAddr} display={this.state.editAddrDisplay}/>*/}
                 <EditInterest token={this.state.token} displayChange={this._displayInter} display={this.state.editInterDisplay}/>
                 <EditLanguage token={this.state.token} displayChange={this._displayLang} display={this.state.editLangDisplay}/>
-                <Spinner size={80} style={{opacity: this.state.spinnerOpacity, flex: 4, position: "absolute", bottom: '43%'}}color='#ccc'/>
+                <Spinner size={80} style={{display: this.state.spinnerDisplay, flex: 4, bottom: '50%'}} color='#555'/>
             </View>
         );
     }

--- a/frontend/Components/Chat/ChatPopup/SearchedChatrooms.js
+++ b/frontend/Components/Chat/ChatPopup/SearchedChatrooms.js
@@ -48,7 +48,7 @@ export default class SearchedChatrooms extends Component {
                                         <Text style={style.font_cr_name}>{chatroom.cr_name}</Text>
                                         <Text style={style.font_cr_intertest}> #{chatroom.interest.section} #{chatroom.interest.group}</Text>
                                         <Icon name='md-people' style={{position : 'absolute', right:10, fontSize: 14, color: '#333'}}>
-                                            <Text style={{fontSize: 12, color: '#333'}}> 14</Text>
+                                            <Text style={{fontSize: 12, color: '#333'}}> {chatroom.participants.lenth}</Text>
                                         </Icon>
                                     </View>
                                 </TouchableOpacity> 

--- a/frontend/Components/Chat/ChatPopup/SearchedChatrooms.js
+++ b/frontend/Components/Chat/ChatPopup/SearchedChatrooms.js
@@ -2,9 +2,6 @@ import React, { Component } from 'react';
 import { View, Text, ScrollView, StyleSheet, TouchableOpacity, ToastAndroid } from 'react-native'
 import { Button, Item, Icon, Label, Input, Left, Body, Right} from 'native-base'
 
-import * as SQLite from 'expo-sqlite';
-const db = SQLite.openDatabase('db.db');
-
 export default class SearchedChatrooms extends Component {
     constructor(props){
         super(props)
@@ -48,7 +45,7 @@ export default class SearchedChatrooms extends Component {
                                         <Text style={style.font_cr_name}>{chatroom.cr_name}</Text>
                                         <Text style={style.font_cr_intertest}> #{chatroom.interest.section} #{chatroom.interest.group}</Text>
                                         <Icon name='md-people' style={{position : 'absolute', right:10, fontSize: 14, color: '#333'}}>
-                                            <Text style={{fontSize: 12, color: '#333'}}> {chatroom.participants.lenth}</Text>
+                                            <Text style={{fontSize: 12, color: '#333'}}> {/*chatroom.participants.length*/}</Text>
                                         </Icon>
                                     </View>
                                 </TouchableOpacity> 

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -147,6 +147,9 @@ export default class Chatroom extends Component {
         BackHandler.addEventListener('hardwareBackPress', this.handleBackButtonClick);
         this.socket.emit('JOIN_ROOM', {cr_id:this.state.cr_id, myEmail:this.state.myEmail})
         this.db_read_chatLog();
+    }
+
+    componentDidMount() {
         this._getParticipants();
     }
 

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -25,7 +25,6 @@ export default class Chatroom extends Component {
         this.messageInput = React.createRef();
         this.socket = io('http://101.101.160.185:3000');
         this.socket.on('RECEIVE_MESSAGE', function(data){
-            console.log(data)
             // TODO : 자동번역을 할지 말지 선택하게 만들어서 자동번역 해주기
             detection(data);
         });
@@ -46,7 +45,6 @@ export default class Chatroom extends Component {
             .then(response => response.json())
             .catch(error => console.error('Error: ', error))
             .then(responseJson => {
-                console.log(responseJson)
                 if (data.user_email == this.state.myEmail || data.user_email == 'PopQuizBot') {
                     db_Add(data);
                 } else {
@@ -74,7 +72,6 @@ export default class Chatroom extends Component {
             .then(response => response.json())
             .catch(error => console.error('Error: ', error))
             .then(responseJson => {
-                console.log(responseJson)
                 if (responseJson.message == undefined) {
                     db_Add(data);
                 } else {

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -239,7 +239,7 @@ export default class Chatroom extends Component {
     };
 
     _goBack = () => {    // 전 화면을 리로드하며 goback을 묶어서 수행하는 함수
-        this.props.navigation.state.params.onNavigateBack()
+        this.props.navigation.state.params.onNavigateBack(this.state.cr_id)
         this.props.navigation.goBack()
     }
 

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -46,8 +46,10 @@ export default class Chatroom extends Component {
             .then(response => response.json())
             .catch(error => console.error('Error: ', error))
             .then(responseJson => {
-                if (data.user_email == this.state.myEmail || data.user_email == 'PopQuizBot') {
+                if (data.user_email == 'PopQuizBot') {
                     db_Add(data);
+                } else if (data.user_email == this.state.myEmail) {
+                    return
                 } else {
                     translate(data, responseJson.langCode);
                 }
@@ -174,7 +176,7 @@ export default class Chatroom extends Component {
                 Time: Date(),
                 message: this.state.message,
             }
-            this.setState({message: ''});    
+            db_Add(newChat)
             this.socket.emit('SEND_MESSAGE', newChat);
         }
     }

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {View, Text, StyleSheet, TouchableOpacity, KeyboardAvoidingView, ScrollView, Dimensions, YellowBox } from 'react-native';
+import {View, Text, StyleSheet, TouchableOpacity, KeyboardAvoidingView, ScrollView, Dimensions, YellowBox, BackHandler} from 'react-native';
 import {Icon, Input, Left, Right} from 'native-base';
 import DrawerLayout from 'react-native-gesture-handler/DrawerLayout';
 
@@ -22,6 +22,7 @@ YellowBox.ignoreWarnings([  // 강제로 에러 안뜨게 하기
 export default class Chatroom extends Component {
     constructor(props){
         super(props);
+        this.handleBackButtonClick = this._goBack.bind(this);
         this.messageInput = React.createRef();
         this.socket = io('http://101.101.160.185:3000');
         this.socket.on('RECEIVE_MESSAGE', function(data){
@@ -143,9 +144,14 @@ export default class Chatroom extends Component {
         this.state.myNickname = navigation.getParam('myNickname', '');
         this.state.myLanguage = navigation.getParam('myLanguage', 'en');
         this.state.favorite = navigation.getParam('favorite', undefined);
+        BackHandler.addEventListener('hardwareBackPress', this.handleBackButtonClick);
         this.socket.emit('JOIN_ROOM', {cr_id:this.state.cr_id, myEmail:this.state.myEmail})
         this.db_read_chatLog();
         this._getParticipants();
+    }
+
+    componentWillUnmount() {
+        BackHandler.removeEventListener('hardwareBackPress', this.handleBackButtonClick);
     }
 
     renderDrawer = () => {
@@ -225,13 +231,16 @@ export default class Chatroom extends Component {
         })
     }
 
-
     handleBackButton = () => {  // 뒤로가기 누르면 전 탭으로 돌아감
-        goback()
+        this._goBack()
     };
 
+    _goBack = () => {    // 전 화면을 리로드하며 goback을 묶어서 수행하는 함수
+        this.props.navigation.state.params.onNavigateBack()
+        this.props.navigation.goBack()
+    }
+
     render() {
-        const { goBack } = this.props.navigation;
         return (
             <DrawerLayout
                 ref={ drawer => this.drawer = drawer }
@@ -242,7 +251,7 @@ export default class Chatroom extends Component {
                 renderNavigationView={this.renderDrawer}>
                 <View style={style.header}>
                     <Left>
-                        <TouchableOpacity onPress={() => {goBack(null)}}>
+                        <TouchableOpacity onPress={() => {this._goBack()}}>
                             <Icon name='md-arrow-round-back' style={{color: '#999', fontSize: 30}}/>
                         </TouchableOpacity>
                     </Left>

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -46,6 +46,7 @@ export default class Chatroom extends Component {
             .then(response => response.json())
             .catch(error => console.error('Error: ', error))
             .then(responseJson => {
+                console.log(responseJson)
                 if (data.user_email == this.state.myEmail || data.user_email == 'PopQuizBot') {
                     db_Add(data);
                 } else {
@@ -73,6 +74,7 @@ export default class Chatroom extends Component {
             .then(response => response.json())
             .catch(error => console.error('Error: ', error))
             .then(responseJson => {
+                console.log(responseJson)
                 if (responseJson.message == undefined) {
                     db_Add(data);
                 } else {

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -47,7 +47,7 @@ export default class Chatroom extends Component {
             .catch(error => console.error('Error: ', error))
             .then(responseJson => {
                 if (data.user_email == 'PopQuizBot') {
-                    db_Add(data);
+                    chatLogAdd(data);
                 } else if (data.user_email == this.state.myEmail) {
                     return
                 } else {
@@ -76,15 +76,15 @@ export default class Chatroom extends Component {
             .catch(error => console.error('Error: ', error))
             .then(responseJson => {
                 if (responseJson.message == undefined) {
-                    db_Add(data);
+                    chatLogAdd(data);
                 } else {
                     data.transMessage = responseJson.message.result.translatedText;
-                    db_Add(data);
+                    chatLogAdd(data);
                 }
             })
         }
 
-        db_Add = (newChat) => {
+        chatLogAdd = (newChat) => {
             this.chatLogAdd(newChat)
             db.transaction( tx => {
                 tx.executeSql(
@@ -115,7 +115,7 @@ export default class Chatroom extends Component {
                 message: question,
                 answer: answer,
             }
-            db_Add(newQuiz)
+            chatLogAdd(newQuiz)
             console.log(newQuiz)
         }
     };
@@ -148,7 +148,7 @@ export default class Chatroom extends Component {
         this.state.favorite = navigation.getParam('favorite', undefined);
         BackHandler.addEventListener('hardwareBackPress', this.handleBackButtonClick);
         this.socket.emit('JOIN_ROOM', {cr_id:this.state.cr_id, myEmail:this.state.myEmail})
-        this.db_read_chatLog();
+        this.db_readChatLog();
     }
 
     componentDidMount() {
@@ -176,7 +176,7 @@ export default class Chatroom extends Component {
                 Time: Date(),
                 message: this.state.message,
             }
-            db_Add(newChat)
+            chatLogAdd(newChat)
             this.socket.emit('SEND_MESSAGE', newChat);
         }
     }
@@ -218,7 +218,7 @@ export default class Chatroom extends Component {
         })
     }
 
-    db_read_chatLog = () => {        // DB 내의 채팅 로그 읽어오기
+    db_readChatLog = () => {        // DB 내의 채팅 로그 읽어오기
         db.transaction( tx => {
             tx.executeSql(
                 'SELECT * FROM chatLog WHERE cr_id = ? LIMIT 200',  //  일단 200개만 읽어오도록

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -227,7 +227,6 @@ export default class Chatroom extends Component {
 
 
     handleBackButton = () => {  // 뒤로가기 누르면 전 탭으로 돌아감
-        this.props.crList_reload()
         goback()
     };
 
@@ -243,7 +242,7 @@ export default class Chatroom extends Component {
                 renderNavigationView={this.renderDrawer}>
                 <View style={style.header}>
                     <Left>
-                        <TouchableOpacity onPress={() => goBack(null)}>
+                        <TouchableOpacity onPress={() => {goBack(null)}}>
                             <Icon name='md-arrow-round-back' style={{color: '#999', fontSize: 30}}/>
                         </TouchableOpacity>
                     </Left>

--- a/frontend/Components/Chat/Chatroom.js
+++ b/frontend/Components/Chat/Chatroom.js
@@ -46,6 +46,7 @@ export default class Chatroom extends Component {
             .then(response => response.json())
             .catch(error => console.error('Error: ', error))
             .then(responseJson => {
+                //console.log(responseJson)
                 if (data.user_email == 'PopQuizBot') {
                     chatLogAdd(data);
                 } else if (data.user_email == this.state.myEmail) {
@@ -75,6 +76,7 @@ export default class Chatroom extends Component {
             .then(response => response.json())
             .catch(error => console.error('Error: ', error))
             .then(responseJson => {
+                //console.log(responseJson)
                 if (responseJson.message == undefined) {
                     chatLogAdd(data);
                 } else {
@@ -236,10 +238,6 @@ export default class Chatroom extends Component {
         })
     }
 
-    handleBackButton = () => {  // 뒤로가기 누르면 전 탭으로 돌아감
-        this._goBack()
-    };
-
     _goBack = () => {    // 전 화면을 리로드하며 goback을 묶어서 수행하는 함수
         this.props.navigation.state.params.onNavigateBack(this.state.cr_id)
         this.props.navigation.goBack()
@@ -301,12 +299,12 @@ export default class Chatroom extends Component {
                     <View style={style.inputPlace}>
                         <Input onChangeText={(message) => this.setState({message})}
                             ref={this.messageInput}
-                            onSubmitEditing={() => {this._onPressSend();}}  // 엔터눌러도 입력되도록 함
+                            onSubmitEditing={() => this._onPressSend()}  // 엔터눌러도 입력되도록 함
                             value={this.state.message}
                             placeholder='Enter message'
-                            style={{marginLeft: 6, fontSize: 16}}/>
+                            style={{fontSize: 16}}/>
                         <TouchableOpacity onPress={() => this._onPressSend()}>
-                            <Icon name='md-send' style={{color: '#555', marginRight: 10, fontSize: 30}}/>
+                            <Icon name='md-send' style={{color: '#555', fontSize: 30}}/>
                         </TouchableOpacity>
                     </View>
                 </KeyboardAvoidingView>
@@ -357,12 +355,13 @@ const style = StyleSheet.create({
         justifyContent: 'flex-start',
     },
     inputPlace: {
-        height: 45,
         width: '100%',
         flexDirection: 'row',
         justifyContent: 'center',
         alignItems: 'center',
         backgroundColor: '#f6f6f6',
+        paddingRight: 10,
+        paddingLeft: 10,
         borderWidth: 0,
     },
     font_main: {

--- a/frontend/Components/Chat/ChatroomTab.js
+++ b/frontend/Components/Chat/ChatroomTab.js
@@ -32,7 +32,7 @@ export default class ChatroomTab extends Component {
             searchBarDisplay: 'none',
             createCRDisplay: 'none',
             searchCRDisplay: 'none',
-            spinnerOpacity: 1,
+            spinnerDisplay: 'flex',
         }
     }
 
@@ -88,7 +88,7 @@ export default class ChatroomTab extends Component {
                             this.setState({arrayHolder: [...this.state.arrayHolder, newItem]})
                         }
                     }
-                    this.setState({spinnerOpacity: 0})
+                    this.setState({spinnerDisplay: 'none'})
                 },
                 (_,error) => console.error(error)
             )
@@ -114,7 +114,7 @@ export default class ChatroomTab extends Component {
     }
 
     _onPressSuggestCRFab = () => {
-        this.setState({spinnerOpacity: 1});
+        this.setState({spinnerDisplay: 'flex'});
         var url = 'http://101.101.160.185:3000/chatroom/recommend';
         fetch(url, {
             method: 'GET',
@@ -137,7 +137,7 @@ export default class ChatroomTab extends Component {
                 }
                 this.setState({suggestedRoom: newItem})
             }
-            this.setState({spinnerOpacity: 0})
+            this.setState({spinnerDisplay: 'none'})
         })
     }
 
@@ -246,7 +246,7 @@ export default class ChatroomTab extends Component {
             return
         }
         this.state.searcharrayHolder.splice(0,100)
-        this.setState({spinnerOpacity: 1});
+        this.setState({spinnerDisplay: 'flex'});
         var url = 'http://101.101.160.185:3000/chatroom/search/'+keyword;
         fetch(url, {
             method: 'GET',
@@ -275,7 +275,7 @@ export default class ChatroomTab extends Component {
                     searchBarDisplay: 'none',
                 })
             }
-            this.setState({spinnerOpacity: 0})
+            this.setState({spinnerDisplay: 'none'})
         })
     }
 
@@ -399,7 +399,7 @@ export default class ChatroomTab extends Component {
                     pushNewRoom={this.insertArrayHolder}
                     displayChange={this._onPressCreateCRFab}
                     display={this.state.createCRDisplay}/>
-                <Spinner size={80} style={{opacity: this.state.spinnerOpacity, flex: 4, position: "absolute", bottom: '43%'}}color='#ccc'/>
+                <Spinner size={80} style={{display: this.state.spinnerDisplay, flex: 4, bottom: '47%'}} color='#777'/>
             </View>
         );
     }

--- a/frontend/Components/Chat/ChatroomTab.js
+++ b/frontend/Components/Chat/ChatroomTab.js
@@ -133,7 +133,7 @@ export default class ChatroomTab extends Component {
                     cr_name: responseJson.name,
                     cr_id: responseJson._id,
                     interest: responseJson.interest,
-                    //memNum: responseJson.participants.length
+                    memNum: responseJson.participants.length
                 }
                 this.setState({suggestedRoom: newItem})
             }

--- a/frontend/Components/Chat/ChatroomTab.js
+++ b/frontend/Components/Chat/ChatroomTab.js
@@ -95,6 +95,47 @@ export default class ChatroomTab extends Component {
         },(error) => console.error(error))
     }
 
+    cr_reload = (cr_id) => {        // 변경사항이 있는 cr 하나만 reload함.
+        db.transaction( tx => {
+            tx.executeSql(
+                'SELECT * FROM crList where cr_id = ?',
+                [cr_id],
+                (_, { rows: { _array }  }) => {
+                    console.log(_array)
+                    changedCR = {
+                        cr_name: _array[0].cr_name,
+                        cr_id: _array[0].cr_id,
+                        interest: {
+                            section: _array[0].section,
+                            group: _array[0]._group
+                        },
+                        memNum: _array[0].memNum,
+                        lastMessage: _array[0].lastMessage,
+                        lastTime: _array[0].lastTime,
+                        favorite: _array[0].favorite
+                    }
+                    for(var i=0;i<this.state.favoriteHolder.length;i++)
+                    {
+                        if (this.state.favoriteHolder[i].cr_id == cr_id) {
+                            this.state.favoriteHolder[i] = changedCR
+                            this.setState({cr_id})  // 배열의 i번째 항목만 setState가 안되기 때문에 넣음
+                            return
+                        }
+                    }
+                    for(var i=0;i<this.state.arrayHolder.length;i++)
+                    {
+                        if (this.state.arrayHolder[i].cr_id == cr_id) {
+                            this.state.arrayHolder[i] = changedCR
+                            this.setState({cr_id})
+                            return
+                        }
+                    }
+                },
+                (_,error) => console.error(error)
+            )
+        },(error) => console.error(error))
+    }
+
     insertArrayHolder = (cr_name, cr_id, interest, memNum) => {       // 새로운 방을 arrayholder이나 DB에 넣는 함수
         newItem = {
             cr_name: cr_name,
@@ -221,10 +262,6 @@ export default class ChatroomTab extends Component {
         );
     }
 
-    handleOnNavigateBack = () => {
-        this.crList_reload()
-    }
-
     _onPressChatroom = (item) => {
         this.props.navigation.navigate('Chatroom', {
             cr_name: item.cr_name,
@@ -234,7 +271,7 @@ export default class ChatroomTab extends Component {
             myNickname: this.state.myNickname,
             myLanguage: this.state.myLanguage,
             favorite: item.favorite,
-            onNavigateBack: this.handleOnNavigateBack
+            onNavigateBack: this.cr_reload
         });
     }
 

--- a/frontend/Components/Chat/ChatroomTab.js
+++ b/frontend/Components/Chat/ChatroomTab.js
@@ -101,7 +101,6 @@ export default class ChatroomTab extends Component {
                 'SELECT * FROM crList where cr_id = ?',
                 [cr_id],
                 (_, { rows: { _array }  }) => {
-                    console.log(_array)
                     changedCR = {
                         cr_name: _array[0].cr_name,
                         cr_id: _array[0].cr_id,

--- a/frontend/Components/Chat/ChatroomTab.js
+++ b/frontend/Components/Chat/ChatroomTab.js
@@ -125,7 +125,7 @@ export default class ChatroomTab extends Component {
         }).then(response => response.json())
         .catch(error => console.error('Error: ', error))
         .then(responseJson => {
-            console.log(responseJson)
+            //console.log(responseJson)
             if(responseJson._id == undefined) {
                 ToastAndroid.show("No chat room found to suit your interests.", ToastAndroid.SHORT)
             } else {
@@ -221,6 +221,10 @@ export default class ChatroomTab extends Component {
         );
     }
 
+    handleOnNavigateBack = () => {
+        this.crList_reload()
+    }
+
     _onPressChatroom = (item) => {
         this.props.navigation.navigate('Chatroom', {
             cr_name: item.cr_name,
@@ -230,7 +234,7 @@ export default class ChatroomTab extends Component {
             myNickname: this.state.myNickname,
             myLanguage: this.state.myLanguage,
             favorite: item.favorite,
-            crList_reload: this.crList_reload()
+            onNavigateBack: this.handleOnNavigateBack
         });
     }
 
@@ -257,7 +261,7 @@ export default class ChatroomTab extends Component {
         }).then(response => response.json())
         .catch(error => console.error('Error: ', error))
         .then(responseJson => {
-            console.log(responseJson)
+            //console.log(responseJson)
             if (responseJson.message == "no search chatroom") {
                 ToastAndroid.show('No rooms searched by this keyword.', ToastAndroid.SHORT);
             } else {

--- a/frontend/Components/Chat/chatbox/mychat.js
+++ b/frontend/Components/Chat/chatbox/mychat.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { Button } from 'native-base';
 
 export default class mychat extends Component {
     render() {
@@ -8,9 +7,9 @@ export default class mychat extends Component {
         return (
             <View style={style.content}>
                 <Text style={style.text_time}>{data.Time.toString().substr(16, 5)}  </Text>
-                <Button info style={style.messageBox}>
+                <Text style={style.messageBox}>
                     <Text style={style.text_message}> {data.message} </Text>
-                </Button>
+                </Text>
             </View>
         );
     }
@@ -24,14 +23,15 @@ const style = StyleSheet.create({
         justifyContent: 'flex-end',
         marginLeft: '30%',
         paddingRight: 10,
-        paddingTop: 5,
-        paddingBottom: 5,
+        paddingTop: 6,
+        paddingBottom: 6,
     },
     messageBox: {
-        paddingLeft: 8,
-        paddingRight: 8,
+        paddingTop: 8,
+        paddingBottom: 8,
+        padding: 5,
         backgroundColor: "#ee3",
-        borderRadius: 6
+        borderRadius: 6,
     },
     text_time: {
         fontSize : 12,

--- a/frontend/Components/Chat/chatbox/otherchat.js
+++ b/frontend/Components/Chat/chatbox/otherchat.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { ToastAndroid, View, Text, StyleSheet, Linking, Alert  } from 'react-native';
-import { Button, Thumbnail } from 'native-base';
+import { ToastAndroid, View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Thumbnail } from 'native-base';
 
 export default class otherchat extends Component {
     constructor() {
@@ -33,9 +33,9 @@ export default class otherchat extends Component {
                         <View style={style.content}>
                             <Thumbnail backgroundColor="#fff" style={style.thumbnail}
                                 source={require('../../../assets/default_thumbnail.png')}/>
-                            <Button style={[style.messageBox,{backgroundColor: '#9f9'}]} onLongPress={() => this._LongPress(data.transMessage)}>
+                            <TouchableOpacity activeOpacity={0.5} style={[style.messageBox,{backgroundColor: '#9f9'}]} onLongPress={() => this._LongPress(data.transMessage)}>
                                 <Text style={style.text_message}>{data.transMessage} </Text>
-                            </Button>
+                            </TouchableOpacity>
                             <View style={style.time_container}>
                                 <Text style={style.text_time}>  translated</Text>
                                 <Text style={style.text_time}>  {data.Time.toString().substr(16, 5)}</Text>
@@ -45,9 +45,9 @@ export default class otherchat extends Component {
                         <View style={style.content}>
                             <Thumbnail backgroundColor="#fff" style={style.thumbnail}
                                 source={require('../../../assets/default_thumbnail.png')}/>
-                            <Button style={[style.messageBox,{backgroundColor: '#ccc'}]} onLongPress={() => this._LongPress(data.transMessage)}>
+                            <TouchableOpacity activeOpacity={0.5} style={[style.messageBox,{backgroundColor: '#ccc'}]} onLongPress={() => this._LongPress(data.transMessage)}>
                                 <Text style={style.text_message}>{data.message} </Text>
-                            </Button>
+                            </TouchableOpacity>
                             <View>
                                 <Text style={style.text_time}>  {data.Time.toString().substr(16, 5)}</Text>
                             </View>
@@ -66,6 +66,7 @@ const style = StyleSheet.create({
         justifyContent: 'flex-start',
         marginRight: '30%',
         paddingLeft: 10,
+        paddingTop: 5,
         paddingBottom: 5,
     },
     thumbnail: {
@@ -75,18 +76,20 @@ const style = StyleSheet.create({
         borderRadius: 45 * 0.4,
     },
     messageBox: {
-        paddingLeft: 8,
-        paddingRight: 8,
+        marginTop: 25,
+        paddingTop: 8,
+        paddingBottom: 8,
+        padding: 5,
         borderRadius: 6
     },
     text_name: {
+        position : 'absolute',
         alignItems: 'flex-end',
         justifyContent: 'flex-end',
         fontSize : 16,
         color: '#000',
-        paddingLeft: 65,
-        paddingTop: 5,
-        marginBottom: 5,
+        top: 5,
+        left: 70,
     },
     text_message: {
         fontSize: 15,

--- a/frontend/Components/Chat/chatbox/quizbot.js
+++ b/frontend/Components/Chat/chatbox/quizbot.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View, Text, StyleSheet, ToastAndroid } from 'react-native';
+import { View, Text, StyleSheet, ToastAndroid, TouchableOpacity } from 'react-native';
 import DialogInput from 'react-native-dialog-input';
 import { Button, Thumbnail } from 'native-base';
 
@@ -12,6 +12,12 @@ export default class quizbot extends Component {
         isActive: true,
         isAlertVisible: false,
         count: 1,
+    }
+
+    _onLongPress = (answer) => {
+        if(answer!=null) {
+            this.setState({isAlertVisible: true})
+        }
     }
 
     isCorrect(answer) {
@@ -50,9 +56,9 @@ export default class quizbot extends Component {
                     <Thumbnail backgroundColor="#fff" style={style.thumbnail}
                         source={require('../../../assets/chatbot.jpg')}/>
                     <View>
-                        <Button style={style.messageBox} onLongPress={() => this.setState({isAlertVisible: true})}>
+                        <TouchableOpacity activeOpacity={0.5} style={style.messageBox} onLongPress={() => this._onLongPress(data.answer)}>
                             <Text style={style.text_message}>{data.message} </Text>
-                        </Button>
+                        </TouchableOpacity>
                     </View>
                     <Text style={style.text_time}>  {data.Time.toString().substr(16, 5)}</Text>
                 </View>
@@ -70,6 +76,7 @@ const style = StyleSheet.create({
         justifyContent: 'flex-start',
         marginRight: '30%',
         paddingLeft: 10,
+        paddingTop: 5,
         paddingBottom: 5,
     },
     thumbnail: {
@@ -79,19 +86,21 @@ const style = StyleSheet.create({
         borderRadius: 45 * 0.4,
     },
     messageBox: {
-        paddingLeft: 8,
-        paddingRight: 8,
+        marginTop: 25,
+        paddingTop: 8,
+        paddingBottom: 8,
+        padding: 5,
+        borderRadius: 6,
         backgroundColor: "#fff",
-        borderRadius: 6
     },
     text_name: {
+        position : 'absolute',
         alignItems: 'flex-end',
         justifyContent: 'flex-end',
         fontSize : 16,
         color: '#444',
-        paddingLeft: 65,
-        paddingTop: 5,
-        marginBottom: 5,
+        top: 5,
+        left: 70,
     },
     text_time: {
         fontSize : 12,

--- a/frontend/Components/TitleScreen.js
+++ b/frontend/Components/TitleScreen.js
@@ -16,7 +16,7 @@ export default class TitleScreen extends Component {
             email: '',
             password: '',
             loginResult: -1,
-            spinnerOpacity: 0,
+            spinnerDisplay: 'none',
         }
     }
     componentWillMount() {
@@ -64,13 +64,13 @@ export default class TitleScreen extends Component {
         else if (this.state.password == ''){
             alert('Please enter your password.');
         } else {
-            this.setState({spinnerOpacity: 1})
+            this.setState({spinnerDisplay: 'flex'})
             this.submit();
             setTimeout(() => {this.checkLoginResult();}, 1000);
         }
     }
     checkLoginResult(){
-        this.setState({spinnerOpacity: 0})
+        this.setState({spinnerDisplay: 'none'})
         if (this.state.loginResult == 0) {           // 잘못된 사용자 정보
             alert("Email or password is incorrect.")
             this.state.loginResult = -1
@@ -134,7 +134,7 @@ export default class TitleScreen extends Component {
                         <Text style={style.text_button}>Log In</Text>
                     </Button>
                 </View>
-                <Spinner size={80} style={{opacity: this.state.spinnerOpacity, flex: 3, position: "absolute", bottom: '50%'}}color='#ddd'/>
+                <Spinner size={80} style={{opacity: this.state.spinnerDisplay, flex: 3, bottom: '50%'}}color='#ddd'/>
             </View>
         );
     }


### PR DESCRIPTION
+ 채팅방 출/입시 지연시간 굉장히 줄어들음.
+ 채팅방에서 나갈 때, 바로 해당 채팅방 수정사항 적용 안되던 문제 수정.
+ 채팅방에서 본인의 채팅은 바로 DB에 저장하도록 방식 변경.
+ 말풍선 컴포넌트 버튼이 아닌 TouchableOpacity로 재구성.

+ 프로필 팝업에서 자꾸 쓰레기값으로 저장되는 문제 수정.
+ 방 추천 인원수 연동 완료

> 백엔드는 로그인시, 방검색시 유저 목록(participants) 발신하도록 수정해주시면 감사하겠습니다.
> 파파고 자동번역 SMT말고 NMT로 재구성해야함. (번역 언어 지원 폭이 차이가 큼)

![ezgif-5-f7178897e8c5](https://user-images.githubusercontent.com/48412823/69566542-aef8c100-0ffa-11ea-9515-f3144630c8b5.gif)
