### PR TITLE
채팅방 나가있을 때 오는 채팅기록 받아오기

### DIFF
--- a/backend/routes/chatroom/chatroom.controller.js
+++ b/backend/routes/chatroom/chatroom.controller.js
@@ -139,7 +139,7 @@ exports.recommend = (req, res) => {
                     {"interest.section" : {$regex : '.*'+user.interests[random_num].section+'.*'}},
                     {"interest.group" : {$regex : '.*'+user.interests[random_num].group+'.*'}}
                 ]).
-                select('interest name').
+                select('interest name participants').
                 sort('interest.group interest.section').
                 limit(10).
                 exec((err, chatroom)=>{ // TODO : 소분류순으로 먼저 나오게 하기

--- a/backend/routes/chatroom/chatroom.controller.js
+++ b/backend/routes/chatroom/chatroom.controller.js
@@ -215,14 +215,23 @@ exports.exit = (req, res) => {
     })
 }
 
-// /*
-//     GET /chatroom/log/:cr_id
-// */
-// exports.getLog = (req, res) => {
-//     var cr_id = req.params.cr_id;
-    
-//     ChatRoom.findOne({_id : cr_id}, function(err, chatroom){ // TODO : 추후에 채팅 기록 소량만 가져올 수 있게끔 수정해야 함.
-//         res.json(chatroom.chatlog);
-//     })
-// }
+/*
+    GET /chatroom/log?cr_id=a&last_message=b
+*/
+exports.getLog = (req, res) => {
+    var cr_id = req.query.cr_id;
+    var last_message = req.query.last_message;
+
+    ChatRoom.findOne({_id : cr_id})
+        .select('chatlog')
+        .exec((err, chatroom) => {
+            if(err) res.json({result : false});
+            for(var i=0; i< chatroom.chatlog.length; i++){
+                if(chatroom.chatlog[i].time == last_message){
+                    chatroom.chatlog.splice(0, i+1);
+                    res.json(chatroom);
+                }
+            }
+        });
+}
 

--- a/backend/routes/chatroom/io.js
+++ b/backend/routes/chatroom/io.js
@@ -8,6 +8,14 @@ module.exports = function (server) {
         console.log(socket.id);
         socket.on('SEND_MESSAGE', function (data) {
             console.log(data);
+            ChatRoom.findOne({_id : data.cr_id}, function(err, chatroom){
+                chatroom.chatlog.push({ // chatroom에 채팅 로그 저장
+                    user_email : data.user_email,
+                    time : data.Time,
+                    message : data.message
+                })
+                chatroom.save();
+            })
             io.sockets.in(data.cr_id).emit('RECEIVE_MESSAGE', data); 
         })
 


### PR DESCRIPTION
1. 채팅방 추천할 때, participants 백엔드에서 함께 보내줘야 하는데 빠져 있어서 수정함.
2. 이제 채팅 로그는 로컬 디비, 서버 디비 둘 다 관리함.
3. 채팅방 밖에 나가 있는 경우, 기존에는 소켓 연결이 끊어져서 다른 사람이 보낸 채팅을 받을 수 없었는데 이제는 서버 디비에 저장하기 때문에 받아올 수 있음. (다만 속도가 좀 느림 -> 개선해야할 부분)

TODO : 
1. 팝퀴즈는 로그에 저장하지 않음. -> 저장할지 말지 고민해야하는 부분(저장한다면 cr_id를 어떻게 해야할지 고민)
2. 채팅 메세지 원본을 저장하기 때문에 번역되지 않음. -> 최근 채팅을 가져올 때 번역해서 보여줄 지 그것도 고민