### PR TITLE
언어교환 백엔드

### DIFF
--- a/backend/models/chatRoom.js
+++ b/backend/models/chatRoom.js
@@ -21,7 +21,11 @@ const ChatRoomSchema = mongoose.Schema({
         user_email:{type: String},
         time: { type: String },
         message: { type: String}
-    }]
+    }],
+    language:{
+        origin:{type:String},
+        dest:{type:String}
+    }
 });
 
 module.exports = mongoose.model('chatroom', ChatRoomSchema);

--- a/backend/routes/chatroom/chatroom.controller.js
+++ b/backend/routes/chatroom/chatroom.controller.js
@@ -19,8 +19,8 @@ exports.searchWord = async (req, res) =>{
         exec((err, chatroom)=>{
             if(err) res.json(err);
             else if(chatroom.length) {
-                var filterChatroom = chatroom.filter((room)=>(room.interest.section != 'Exchanging Language'))
-                res.json(filterChatroom);
+                var filteredChatroom = chatroom.filter((room)=>(room.interest.section != 'Exchanging Language'))
+                res.json(filteredChatroom);
             }
             else res.json(({result : true, message : "no search chatroom"}));
         })
@@ -133,7 +133,8 @@ exports.recommend = (req, res) => {
                 var random = Math.floor(Math.random() * 5);
                 ChatRoom.find().skip(random).limit(5).exec((err, chatroom) => {
                     //array말고 단일 object로 보내기
-                    var selected = chatroom[0];
+                    var filteredChatroom = chatroom.filter((room)=>(room.interest.section != 'Exchanging Language'));
+                    var selected = filteredChatroom[0];
                     res.json(selected);
                 })      
             }
@@ -152,13 +153,15 @@ exports.recommend = (req, res) => {
                         var random = Math.floor(Math.random() * 5);
                         ChatRoom.find().skip(random).limit(5).exec((err, chatroom) => {
                             //array말고 단일 object로 보내기
-                            var selected = chatroom[0];
+                            var filteredChatroom = chatroom.filter((room)=>(room.interest.section != 'Exchanging Language'));
+                            var selected = filteredChatroom[0];
                             res.json(selected);
                         })     
                     }
                     else{
-                        var random = Math.floor(Math.random() * chatroom.length);
-                        var selected = chatroom[random];
+                        var filteredChatroom = chatroom.filter((room)=>(room.interest.section != 'Exchanging Language'));
+                        var random = Math.floor(Math.random() * filteredChatroom.length);
+                        var selected = filteredChatroom[random];
                         res.json(selected);
                     }
                 })

--- a/backend/routes/chatroom/chatroom.controller.js
+++ b/backend/routes/chatroom/chatroom.controller.js
@@ -307,9 +307,10 @@ exports.exchangeLanCreation = (req, res) => {
             exec((err, chatroom) => {
                 if(err) res.json({result: false, message:"fail"});
                 else if(chatroom.length){
-                    res.json(chatroom);
+                    var filteredChatroom = chatroom.filter((room) => (room.participants.length==1));
+                    res.json(filteredChatroom);
                 }
-                else res.json({result: true, message: "no found chatroom"});
+                else res.json({result: true, message: "no search chatroom"});
             })
 
      })

--- a/backend/routes/chatroom/chatroom.controller.js
+++ b/backend/routes/chatroom/chatroom.controller.js
@@ -308,9 +308,12 @@ exports.exchangeLanCreation = (req, res) => {
                 if(err) res.json({result: false, message:"fail"});
                 else if(chatroom.length){
                     var filteredChatroom = chatroom.filter((room) => (room.participants.length==1));
-                    res.json(filteredChatroom);
+                    if(filteredChatroom.length){
+                        res.json(filteredChatroom);
+                    }
+                    else res.json({message: "no search chatroom"});
                 }
-                else res.json({result: true, message: "no search chatroom"});
+                
             })
 
      })

--- a/backend/routes/chatroom/chatroom.controller.js
+++ b/backend/routes/chatroom/chatroom.controller.js
@@ -5,7 +5,7 @@ var User = require('../../models/user');
 /*
     GET /chatroom/search/:keyword
 */
-exports.searchWord = (req, res) =>{
+exports.searchWord = async (req, res) =>{
     var keyword = req.params.keyword;
 
     ChatRoom.find().
@@ -18,7 +18,10 @@ exports.searchWord = (req, res) =>{
         sort('name').
         exec((err, chatroom)=>{
             if(err) res.json(err);
-            else if(chatroom.length) res.json(chatroom);
+            else if(chatroom.length) {
+                var filterChatroom = chatroom.filter((room)=>(room.interest.section != 'Exchanging Language'))
+                res.json(filterChatroom);
+            }
             else res.json(({result : true, message : "no search chatroom"}));
         })
 }

--- a/backend/routes/chatroom/chatroom.controller.js
+++ b/backend/routes/chatroom/chatroom.controller.js
@@ -5,7 +5,7 @@ var User = require('../../models/user');
 /*
     GET /chatroom/search/:keyword
 */
-exports.searchWord = async (req, res) =>{
+exports.searchWord = (req, res) =>{
     var keyword = req.params.keyword;
 
     ChatRoom.find().

--- a/backend/routes/chatroom/index.js
+++ b/backend/routes/chatroom/index.js
@@ -7,6 +7,8 @@ router.use('/list', authMiddleware);
 router.use('/recommend', authMiddleware);
 router.use('/exit/:cr_id', authMiddleware);
 router.use('/entrance/:cr_id', authMiddleware);
+router.use('/exchange-language/creation', authMiddleware);
+router.use('/exchange-language/:language', authMiddleware);
 
 router.get('/search/:keyword', controller.searchWord);
 router.post('/creation', controller.creation);
@@ -16,5 +18,6 @@ router.post('/log', controller.getLog);
 router.get('/participants/:cr_id', controller.getParticipants);
 router.get('/recommend', controller.recommend);
 router.post('/entrance/:cr_id', controller.entrance);
-
+router.post('/exchange-language/creation', controller.exchangeLanCreation);
+router.get('/exchange-language/:language', controller.exchangeLanSearch);
 module.exports = router;


### PR DESCRIPTION
1. models/chatroom에 언어교환에 사용할 language 변수 추가
2. 방 검색, 추천할때는 언어교환에 대한 방은 예외시킴
3. 언어교환에 대한 방 검색, 생성 로직 추가

> 언어교환 로직
+ 한글을 쓰는 A유저, 영어를 쓰는 B유저
+ A유저가 영어를 쓰는 사용자와 채팅하기 위하여 영어를 선택해서 언어교환 방을 만듦.
+ B유저가 한글을 쓰는 사용자와 채팅하고 싶어서 한글을 선택해서 검색하면 A유저가 만들었던 방 목록이 보임.